### PR TITLE
Update role to support Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# shared/squid3 #
+# shared/squid #
 
-Ensures squid3 is installed and configured.
+Ensures squid is installed and configured.
 Customized from squid role created by Kevin Brebanov on ansible-galaxy.
 
 ## Requirements ##
@@ -53,15 +53,15 @@ Requires Ansible 2.0.
 
     - name: squid_packages
       desc: List of squid packages to install
-      value: squid3
+      value: squid
 
     - name: squid_etc_dir
       desc: path to squid configuration directory
-      value: /etc/squid3
+      value: /etc/squid
 
     - name: squid_service_name
       desc: Name of squid service
-      value: squid3
+      value: squid
 
 
 ## Dependencies ##
@@ -77,4 +77,3 @@ None.
     - hosts: all
       roles:
         - role: shared/squid
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,3 @@ squid_http_port: 3128
 squid_never_directs: []
 squid_proxy_only: true
 squid_tcp_outgoing_address: ''
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - trusty
+    - xenial
   galaxy_tags:
     - proxy
 dependencies: []

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -1,5 +1,5 @@
 logformat traveloka %tg %6tr %>a %Ss/%03>Hs %<st %rm %ru %[un %Sh/%<a %mt
-access_log daemon:/var/log/squid3/access.log traveloka
+access_log daemon:/var/log/squid/access.log traveloka
 
 {% if squid_ssl_ports %}
 {% for ssl_port in squid_ssl_ports %}
@@ -40,7 +40,7 @@ cache_peer {{ cache_peer.hostname }} {{ cache_peer.type }} {{ cache_peer.proxy_p
 {% else %}
 {% endif %}
 
-coredump_dir /var/spool/squid3
+coredump_dir /var/spool/squid
 refresh_pattern ^ftp:		1440	20%	10080
 refresh_pattern ^gopher:	1440	0%	1440
 refresh_pattern -i (/cgi-bin/|\?) 0	0%	0

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
 
   # define machines
   machines = []
-  machines << { name: "trusty", box: "ubuntu/trusty64" }
+  machines << { name: "xenial", box: "ubuntu/xenial64" }
 
   # iterate through machines
   machines.each do |machine|

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 # vars file for squid
 
 squid_packages:
-  - squid3
-squid_etc_dir: /etc/squid3
-squid_confd_dir: /etc/squid3/conf.d
-squid_service_name: squid3
+  - squid
+squid_etc_dir: /etc/squid
+squid_confd_dir: /etc/squid/conf.d
+squid_service_name: squid


### PR DESCRIPTION
- Support installation on Ubuntu 16 Xenial
- Remove support on Ubuntu 14 Trusty

This change will break compatibility.